### PR TITLE
Fixed bug when `Component` is `undefined`

### DIFF
--- a/src/AsyncComponent.js
+++ b/src/AsyncComponent.js
@@ -25,7 +25,7 @@ const asyncComponent = loadComponent => (
     }
     
     hasLoadedComponent() {
-      return this.state.Component !== null;
+      return this.state.Component != null;
     }
     
     render() {


### PR DESCRIPTION
Fixed bug when `Component` is `undefined`, the `hasLoadedComponent()` will return `true` wrongly.